### PR TITLE
Revise docs for language and technical errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
 <header class="jumbotron subhead">
   <div class="container">
       <h1>Bootstrap Confirmation</h1>
-    <p class="lead">jQuery plugin for Twitter Bootstrap. It will help you create confirmation dialog as popover. Simple and easy like popover.</p>
+    <p class="lead">jQuery plugin for Twitter Bootstrap. Use Bootstrap Popovers as confirmation dialogs. Simple and easy.</p>
   </div>
 </header>
 
@@ -75,15 +75,8 @@
         <!-- Overview
         ================================================== -->
         <section id="intro">
-          <div class="page-header">
-            <h1>Bootstrap Confirmation</h1>
-          </div>
-
-          <h3>Do you bore about alert box?</h3>
-          <p>This is my primary reason that I write this plugin. I want simple box for job about comfirm something before do another. Popover is my choice so I write this plugin with popover be base of it.</p>
-
-          <h3>Before you read next after this.</h3>
-          <p>I'm Thai so my English isn't good so if you see some text that make you want to retype or rearrange, please don't hesitate to create pull request with text that you edited. I will happy that my English can better after your guide too.</p>
+          <h3>Let's face it: Confirmation dialog boxes are annoying</h3>
+          <p>This is my primary reason I wrote this plugin. I wanted a simple box to comfirm a task. Instead of using rude boxes that interrupt a user's workflow, <strong>let's use a popover instead</strong>. </p>
         </section>
 
 
@@ -92,13 +85,18 @@
             <h1>Installation</h1>
           </div>
 
-          <p>Download <a href="https://raw.github.com/ethaizone/Bootstrap-Confirmation/master/bootstrap-confirmation.js" target="_blank">bootstrap-confirmation.js</a> and save to same directory with bootstrap.js. Call it with &lt;script&gt; tag.</p>
+          <p>Download <a href="https://raw.github.com/ethaizone/Bootstrap-Confirmation/master/bootstrap-confirmation.js" target="_blank">bootstrap-confirmation.js</a>. Include after <code>jquery.js</code> and <code>bootstrap-tooltip.js</code>.</p>
+            <pre class="prettyprint"><code class="html">&lt;script type=&quot;text/javascript&quot; src=&quot;path/to/jquery.js&quot;&gt;&lt;/script&gt;
+&lt;script type=&quot;text/javascript&quot; src=&quot;path/to/bootstrap-tooltip.js&quot;&gt;&lt;/script&gt;
+&lt;script type=&quot;text/javascript&quot; src=&quot;path/to/bootstrap-confirmation.js&quot;&gt;&lt;/script&gt;</code></pre>
+          <h3>CSS</h3>
+          <p>The plugin uses the default popover styling Bootstrap provides.</p>
 
-          <h3>What about css?</h3>
-          <p>No need another css. It will use same stylesheet as popover because this plugin build with concept that I want it must look like popover.</p>
-
-          <h3>JS dependency?</h3>
-          <p>As same as bootstrap.js. It want JQuery, bootstrap.js and bootstrap-tooltip.js. This confirmation extended from tooltip so tooltip must call at your webpage. If you use bootstrap.min.js, bootstrap-tooltip.js should inclued.</p>
+          <h3>JS Dependencies</h3>
+          <ul>
+              <li><a href="http://jquery.com">jQuery</a></li>
+              <li><a href="http://getbootstrap.com/2.3.2/">Bootstrap Tooltip</a> (included in bootstrap.js)</li>
+          </ul>
         </section>
 
         <section id="example">
@@ -107,7 +105,7 @@
           </div>
 
 
-          <p>Add small overlays of content, like those on the iPad, to any element for housing button "Yes" and "No". Click the button to trigger the confirmation. <strong>Requires <a href="#tooltips">Tooltip</a> to be included.</strong></p>
+          <p>Add small overlays with "Yes" and "No" buttons, like those on the iPad, to any element. Click the button to trigger the confirmation.</p>
 
           <h3>Live demo</h3>
           <div class="bs-docs-example" style="padding-bottom: 24px;">
@@ -174,39 +172,39 @@
                <td>animation</td>
                <td>boolean</td>
                <td>true</td>
-               <td>apply a css fade transition to the tooltip</td>
+               <td>Apply a CSS fade transition to the tooltip</td>
              </tr>
              <tr>
                <td>placement</td>
                <td>string | function</td>
-               <td>'right'</td>
-               <td>how to position the confirmation - top | bottom | left | right</td>
+               <td>'top'</td>
+               <td>How to position the confirmation - top | bottom | left | right</td>
              </tr>
              <tr>
                <td>selector</td>
                <td>string</td>
                <td>false</td>
-               <td>if a selector is provided, tooltip objects will be delegated to the specified targets</td>
+               <td>If a selector is provided, tooltip objects will be delegated to the specified targets</td>
              </tr>
              <tr>
                <td>trigger</td>
                <td>string</td>
                <td>'click'</td>
-               <td>how confirmation is triggered - click | hover | focus | manual</td>
+               <td>How confirmation is triggered - click | hover | focus | manual</td>
              </tr>
              <tr>
                <td>title</td>
                <td>string | function</td>
                <td>'Are you sure?'</td>
-               <td>default title value if `data-title` attribute isn't present</td>
+               <td>Default title value if `data-title` attribute isn't present</td>
              </tr>
              <tr>
                <td>href</td>
                <td>string | function</td>
                <td>'#'</td>
                <td>
-                <p>default href value if `data-href` attribute isn't present.</p>
-                <p>This will be link of "Ok" button.</p>
+                <p>Default href value if `data-href` attribute isn't present.</p>
+                <p>This will be link of the "Ok" button.</p>
                </td>
              </tr>
              <tr>
@@ -214,8 +212,8 @@
                <td>string | function</td>
                <td>'_self'</td>
                <td>
-                <p>default target value if `data-target` attribute isn't present.</p>
-                <p>This will be target of link at "Ok" button.</p>
+                <p>Default target value if `data-target` attribute isn't present.</p>
+                <p>This will be target of the "Ok" button.</p>
                </td>
              </tr>
              <tr>
@@ -223,8 +221,8 @@
                <td>string | function</td>
                <td>'btn-primary'</td>
                <td>
-                <p>default btnOkClass value if `data-btnOkClass` attribute isn't present.</p>
-                <p>This will be class of link at "Ok" button.</p>
+                <p>Default btnOkClass value if `data-btnOkClass` attribute isn't present.</p>
+                <p>This will be class of the "Ok" button.</p>
                </td>
              </tr>
              <tr>
@@ -232,8 +230,8 @@
                <td>string | function</td>
                <td>''</td>
                <td>
-                <p>default btnCancelClass value if `data-btnCancelClass` attribute isn't present.</p>
-                <p>This will be class of link at "Cancel" button.</p>
+                <p>Default btnCancelClass value if `data-btnCancelClass` attribute isn't present.</p>
+                <p>This will be class of the "Cancel" button.</p>
                </td>
              </tr>
              <tr>
@@ -241,8 +239,8 @@
                <td>string | function</td>
                <td nowrap>'&lt;i class="icon-ok-sign icon-white"&gt;&lt;/i&gt; Yes'</td>
                <td>
-                <p>default btnOkLabel value if `data-btnOkLabel` attribute isn't present.</p>
-                <p>This will be label of link at "Ok" button.</p>
+                <p>Default btnOkLabel value if `data-btnOkLabel` attribute isn't present.</p>
+                <p>This will be label of the "Ok" button.</p>
                </td>
              </tr>
              <tr>
@@ -250,8 +248,8 @@
                <td>string | function</td>
                <td nowrap>'&lt;i class="icon-remove-sign"&gt;&lt;/i&gt; No'</td>
                <td>
-                <p>default btnCancelLabel value if `data-btnCancelLabel` attribute isn't present.
-                <p>This will be label of link at "Cancel" button.</td>
+                <p>Default btnCancelLabel value if `data-btnCancelLabel` attribute isn't present.
+                <p>This will be label of the "Cancel" button.</td>
              </tr>
              <tr>
                <td>
@@ -261,8 +259,8 @@
                <td>boolean</td>
                <td>false</td>
                <td>
-                <p>Set true for make confirmation can show only 1 instanse.</p>
-                <p>If newer confirmation clicked, older will disappear.</td>
+                <p>Set true to allow only one confirmation to show at a time.</p>
+                <p>When the newest confirmation element is clicked, the older ones will disappear.</td>
              </tr>
              <tr>
                <td>
@@ -272,16 +270,16 @@
                <td>boolean</td>
                <td>false</td>
                <td>
-                <p>Set true for make confirmation hide when click on anywhere except itself.</p>
-                <p>It will effect with other that use same selector too.</td>
+                <p>Set true to hide the confirmation when user clicks outside of it.</p>
+                <p>This will affect all confirmations that use same selector.</td>
              </tr>
              <tr>
                <td>delay</td>
                <td>number | object</td>
                <td>0</td>
                <td>
-                <p>delay showing and hiding the confirmation (ms) - does not apply to manual trigger type</p>
-                <p>If a number is supplied, delay is applied to both hide/show</p>
+                <p>Delay showing and hiding the confirmation (ms) - does not apply to manual trigger type.</p>
+                <p>If a number is supplied, delay is applied to both hide/show.</p>
                 <p>Object structure is: <code>delay: { show: 500, hide: 100 }</code></p>
                </td>
              </tr>


### PR DESCRIPTION
I've revised the docs for any English errors.

Also, the default `placement` was documented incorrectly. That is now fixed.

Thanks for this plugin!
